### PR TITLE
fix: use registry modules in standalone_single_project example

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -14,6 +14,9 @@
 
 timeout: 3600s
 steps:
+- id: swap-module-refs
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && module-swapper']
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && sleep 120']

--- a/examples/standalone_single_project/cicd.tf
+++ b/examples/standalone_single_project/cicd.tf
@@ -52,6 +52,7 @@ locals {
 module "ci_pipeline" {
   source  = "GoogleCloudPlatform/secure-cicd/google//modules/secure-ci"
   version = "0.2.0"
+
   project_id                = var.project_id
   app_source_repo           = "${var.app_name}-source"
   cloudbuild_cd_repo        = "${var.app_name}-cloudbuild-cd-config"
@@ -71,6 +72,7 @@ module "ci_pipeline" {
 module "cd_pipeline" {
   source  = "GoogleCloudPlatform/secure-cicd/google//modules/secure-cd"
   version = "0.2.0"
+
   project_id       = var.project_id
   primary_location = var.region
 

--- a/examples/standalone_single_project/cicd.tf
+++ b/examples/standalone_single_project/cicd.tf
@@ -50,7 +50,8 @@ locals {
 
 # Secure-CI
 module "ci_pipeline" {
-  source                    = "../../modules/secure-ci"
+  source  = "GoogleCloudPlatform/secure-cicd/google//modules/secure-ci"
+  version = "0.2.0"
   project_id                = var.project_id
   app_source_repo           = "${var.app_name}-source"
   cloudbuild_cd_repo        = "${var.app_name}-cloudbuild-cd-config"
@@ -68,7 +69,8 @@ module "ci_pipeline" {
 
 # Secure-CD
 module "cd_pipeline" {
-  source           = "../../modules/secure-cd"
+  source  = "GoogleCloudPlatform/secure-cicd/google//modules/secure-cd"
+  version = "0.2.0"
   project_id       = var.project_id
   primary_location = var.region
 
@@ -86,7 +88,8 @@ module "cd_pipeline" {
 
 # Cloud Build Private Pool
 module "cloudbuild_private_pool" {
-  source = "../../modules/cloudbuild-private-pool"
+  source  = "GoogleCloudPlatform/secure-cicd/google//modules/cloudbuild-private-pool"
+  version = "0.2.0"
 
   project_id                = var.project_id
   network_project_id        = var.project_id
@@ -99,5 +102,3 @@ module "cloudbuild_private_pool" {
   worker_address    = "10.39.0.0"
   worker_range_name = "cloudbuild-worker-range"
 }
-
-

--- a/examples/standalone_single_project/network.tf
+++ b/examples/standalone_single_project/network.tf
@@ -63,7 +63,8 @@ resource "google_compute_network_peering_routes_config" "gke_peering_routes_conf
 
 # Cloud Build Workerpool <-> GKE HA VPNs
 module "gke_cloudbuild_vpn" {
-  source = "../../modules/workerpool-gke-ha-vpn"
+  source  = "GoogleCloudPlatform/secure-cicd/google//modules/workerpool-gke-ha-vpn"
+  version = "0.2.0"
 
   project_id = var.project_id
   location   = var.region


### PR DESCRIPTION
* Use published modules in Terraform registry inside the standalone_single_project example
* Add [module-swapper](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/infra/build/developer-tools/build/scripts/module-swapper) in integration build pipeline