### PR TITLE
fix: API errors in app_cicd example

### DIFF
--- a/examples/app_cicd/README.md
+++ b/examples/app_cicd/README.md
@@ -19,49 +19,55 @@ To deploy this example:
 mkdir cicd-example
 cd cicd-example
 ```
-2. Clone `secure-cicd` repo
+1. Clone `secure-cicd` repo
 ```sh
 git clone https://github.com/GoogleCloudPlatform/terraform-google-secure-cicd.git
 ```
-3. Run `terraform init` from within this example directory.
+1. Run `terraform init` to enable the proper APIs.
+```sh
+cd terraform-google-secure-cicd/examples/app_cicd/configure-project
+terraform init
+```
+1. Create a `terraform.tfvars` file to provide values for `project_id`.
+1. Run `terraform apply` to enable the proper APIs.
+1. Run `terraform init` from within this example directory.
 ```sh
 cd terraform-google-secure-cicd/examples/app_cicd
 terraform init
 ```
-4. Create a `terraform.tfvars` file to provide values for `project_id` and `deploy_branch_clusters`. Optionally override any variables if necessary.
-
-5. Run `terraform apply` within this example directory.
+1. Create a `terraform.tfvars` file to provide values for `project_id` and `deploy_branch_clusters`. Optionally override any variables if necessary.
+1. Run `terraform apply` within this example directory.
 
 ### Sample application configuration
-6. Export CI/CD project ID
+1. Export CI/CD project ID
 ```sh
 export PROJECT_ID=<CICD Project ID>
 ```
-7. Return to working directory
+1. Return to working directory
 ```sh
 cd ../../..
 ```
-8. Clone the Bank of Anthos sample application repo
+1. Clone the Bank of Anthos sample application repo
 ```sh
 git clone --branch v0.5.3 https://github.com/GoogleCloudPlatform/bank-of-anthos.git
 ```
-9. Clone the `app-dry-manifests` repo
+1. Clone the `app-dry-manifests` repo
 ```sh
 gcloud source repos clone app-dry-manifests --project=$PROJECT_ID
 ```
-10. Copy the Bank of Anthos Kubernetes manifests to the `app-dry-manifests` repo
+1. Copy the Bank of Anthos Kubernetes manifests to the `app-dry-manifests` repo
 ```sh
 cp bank-of-anthos/dev-kubernetes-manifests/* app-dry-manifests/
 ```
-11. Copy the Skaffold config to the `app-dry-manifests` repo
+1. Copy the Skaffold config to the `app-dry-manifests` repo
 ```sh
 cp bank-of-anthos/skaffold.yaml app-dry-manifests/
 ```
-12. Replace Skaffold manifest paths with repo path
+1. Replace Skaffold manifest paths with repo path
 ```sh
 sed -i 's/dev-kubernetes-manifests/app-dry-manifests/g' app-dry-manifests/skaffold.yaml
 ```
-13. Push `app-dry-manifests` changes
+1. Push `app-dry-manifests` changes
 ```sh
 cd app-dry-manifests/
 git add .
@@ -70,35 +76,35 @@ git push
 cd ..
 ```
 
-14. Copy `cloudbuild-ci.yaml` to `app-source` repo
+1. Copy `cloudbuild-ci.yaml` to `app-source` repo
 ```sh
 cp terraform-google-secure-cicd/build/cloudbuild-ci.yaml bank-of-anthos/
 ```
-15. Copy `policies` folder to `app-source` repo
+1. Copy `policies` folder to `app-source` repo
 ```sh
 cp -R terraform-google-secure-cicd/examples/app_cicd/policies bank-of-anthos/policies
 ```
 
-16. Add `app-source` repo as new remote for Bank of Anthos source code and push
+1. Add `app-source` repo as new remote for Bank of Anthos source code and push
 ```sh
 cd bank-of-anthos
 git remote add google https://source.developers.google.com/p/$PROJECT_ID/r/app-source
 git push --all google
 ```
-17. Return to working directory
+1. Return to working directory
 ```sh
 cd ..
 ```
-18. Clone `app-wet-manifests` repo
+1. Clone `app-wet-manifests` repo
 ```sh
 gcloud source repos clone app-wet-manifests --project=$PROJECT_ID
 ```
 
-19. Copy `cloudbuild-cd.yaml` to `app-wet-manifests` repo
+1. Copy `cloudbuild-cd.yaml` to `app-wet-manifests` repo
 ```sh
 cp terraform-google-secure-cicd/build/cloudbuild-cd.yaml app-wet-manifests/
 ```
-20. Push changes in `app-wet-manifests` repo
+1. Push changes in `app-wet-manifests` repo
 ```sh
 cd app-wet-manifests
 git add .

--- a/examples/app_cicd/configure-project/main.tf
+++ b/examples/app_cicd/configure-project/main.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Provider configuration
+ *****************************************/
+module "project-services" {
+  source                      = "terraform-google-modules/project-factory/google//modules/project_services"
+  project_id                  = var.project_id
+  enable_apis                 = var.enable
+  disable_services_on_destroy = true
+
+  activate_apis = [
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "clouddeploy.googleapis.com",
+    "sourcerepo.googleapis.com",
+    "container.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "cloudkms.googleapis.com",
+    "containeranalysis.googleapis.com"
+  ]
+}

--- a/examples/app_cicd/configure-project/outputs.tf
+++ b/examples/app_cicd/configure-project/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = module.project-services.project_id
+  description = "The GCP project you want to enable APIs on"
+}

--- a/examples/app_cicd/configure-project/variables.tf
+++ b/examples/app_cicd/configure-project/variables.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The GCP project you want to enable APIs on"
+}
+
+variable "enable" {
+  description = "Actually enable the APIs listed"
+  default     = true
+}

--- a/examples/app_cicd/configure-project/versions.tf
+++ b/examples/app_cicd/configure-project/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.5"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.5"
+    }
+  }
+}


### PR DESCRIPTION
**Problem:** following `examples/app_cicd/README.md` as is results in the following errors after the first `terraform apply`:

```
│ Error: Error creating Repository: googleapi: Error 403: Cloud Source Repositories API has not been used in project 452133441630 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sourcerepo.googleapis.com/overview?project=452133441630 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
...
│ Error: Error creating Repository: googleapi: Error 403: Artifact Registry API has not been used in project 452133441630 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/artifactregistry.googleapis.com/overview?project=452133441630 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
...
```

**Solution:** I added `examples/app_cicd/configure-project` terraform which enables APIs on the project and updated `examples/app_cicd/README.md`. Running that prior to running `terraform apply` in the `examples/app_cicd` fixes the problem above. Also note, for some reason I get the above errors if I merge the `examples/app_cicd/configure-project/main.tf` terraform with the `examples/app_cicd/main.tf` terraform. I confirmed the steps in `app_cicd/README.md` work with my changes.

I also added a small quality of life enhancement to `examples/app_cicd/README.md` by changing the numbering to just use `1.` which markdown will automatically interpret to the proper number when it renders.

