### PR TITLE
chore: restrict vpn_ha version to not pick up 2.3.2

### DIFF
--- a/modules/workerpool-gke-ha-vpn/main.tf
+++ b/modules/workerpool-gke-ha-vpn/main.tf
@@ -17,7 +17,7 @@
 # HA VPN
 module "vpn_ha_1" {
   source     = "terraform-google-modules/vpn/google//modules/vpn_ha"
-  version    = "~> 2.3.0"
+  version    = "~> 2.3.0, != 2.3.2"
   project_id = var.project_id
   labels     = var.labels
   region     = var.location
@@ -62,7 +62,7 @@ module "vpn_ha_1" {
 
 module "vpn_ha_2" {
   source     = "terraform-google-modules/vpn/google//modules/vpn_ha"
-  version    = "~> 2.3.0"
+  version    = "~> 2.3.0, != 2.3.2"
   project_id = var.gke_project
   labels     = var.labels
   region     = var.gke_location


### PR DESCRIPTION
The release introduced with 2.3.2 is picked up by this module.

This PR ensures we don't pick up 2.3.2 as it's breaking and restricts tf version as well as introduces new variables.

BEGIN_COMMIT_OVERRIDE
fix: restrict vpn_ha version to not pick up 2.3.2
END_COMMIT_OVERRIDE