### PR TITLE
fix: ha vpn module version again

### DIFF
--- a/modules/workerpool-gke-ha-vpn/main.tf
+++ b/modules/workerpool-gke-ha-vpn/main.tf
@@ -17,7 +17,7 @@
 # HA VPN
 module "vpn_ha_1" {
   source     = "terraform-google-modules/vpn/google//modules/vpn_ha"
-  version    = "~> 2.3.0, != 2.3.2"
+  version    = "~> 2.3.0, < 2.3.2"
   project_id = var.project_id
   labels     = var.labels
   region     = var.location

--- a/modules/workerpool-gke-ha-vpn/main.tf
+++ b/modules/workerpool-gke-ha-vpn/main.tf
@@ -62,7 +62,7 @@ module "vpn_ha_1" {
 
 module "vpn_ha_2" {
   source     = "terraform-google-modules/vpn/google//modules/vpn_ha"
-  version    = "~> 2.3.0, != 2.3.2"
+  version    = "~> 2.3.0, < 2.3.2"
   project_id = var.gke_project
   labels     = var.labels
   region     = var.gke_location


### PR DESCRIPTION
2.3.3 was released still containing breaking changes from 2.3.2. So just restricting it to below 2.3.2